### PR TITLE
Fix read-the-doc-link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ so that rollbacks to old versions of configuration work correctly.
 Documentation
 -------------
 
-The full documentation is at https://config_models.readthedocs.org.
+The full documentation is at https://django-config-models.readthedocs.org.
 
 License
 -------


### PR DESCRIPTION
For issue #143.

Correct URL is "https://django-config-models.readthedocs.io/en/latest/"

Verified by pushing the branch and checking the link.