### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip install -r requirements/pip-tools.txt
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --no-emit-trusted-host --no-emit-index-url --rebuild --upgrade -o requirements/doc.txt requirements/doc.in

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -113,7 +113,7 @@ class ConfigurationModel(models.Model):
     @classmethod
     def cache_key_name(cls, *args):
         """Return the name of the key to use to cache the current configuration"""
-        if cls.KEY_FIELDS != ():    # pylint: disable=use-implicit-booleaness-not-comparison
+        if cls.KEY_FIELDS != ():
             if len(args) != len(cls.KEY_FIELDS):
                 raise TypeError(
                     f"cache_key_name() takes exactly {len(cls.KEY_FIELDS)} arguments ({len(args)} given)"

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -113,10 +113,10 @@ class ConfigurationModel(models.Model):
     @classmethod
     def cache_key_name(cls, *args):
         """Return the name of the key to use to cache the current configuration"""
-        if cls.KEY_FIELDS != ():
+        if cls.KEY_FIELDS != ():  # pylint: disable=use-implicit-booleaness-not-comparison
             if len(args) != len(cls.KEY_FIELDS):
                 raise TypeError(
-                    f"cache_key_name() takes exactly {len(cls.KEY_FIELDS)} arguments ({len(args)} given)" # pylint: disable=use-implicit-booleaness-not-comparison
+                    f"cache_key_name() takes exactly {len(cls.KEY_FIELDS)} arguments ({len(args)} given)"
                 )
             return f"configuration/{cls.__name__}/current/{','.join(str(arg) for arg in args)}"
         else:

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -116,7 +116,7 @@ class ConfigurationModel(models.Model):
         if cls.KEY_FIELDS != ():
             if len(args) != len(cls.KEY_FIELDS):
                 raise TypeError(
-                    f"cache_key_name() takes exactly {len(cls.KEY_FIELDS)} arguments ({len(args)} given)"
+                    f"cache_key_name() takes exactly {len(cls.KEY_FIELDS)} arguments ({len(args)} given)" # pylint: disable=use-implicit-booleaness-not-comparison
                 )
             return f"configuration/{cls.__name__}/current/{','.join(str(arg) for arg in args)}"
         else:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -21,7 +21,7 @@ class AdminTestCaseMixin:
     Provide a request factory method.
     """
 
-    def get_request(self):
+    def get_request(self):  # pylint: disable=no-self-use
         request = HttpRequest()
         request.session = "session"
         request._messages = FallbackStorage(request)  # pylint: disable=protected-access

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -21,7 +21,7 @@ class AdminTestCaseMixin:
     Provide a request factory method.
     """
 
-    def get_request(self):  # pylint: disable=no-self-use
+    def get_request(self):
         request = HttpRequest()
         request.session = "session"
         request._messages = FallbackStorage(request)  # pylint: disable=protected-access

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,7 @@ class CacheIsolationMixin:
 
         cls.__old_settings.append(copy.deepcopy(settings.CACHES))
         override = override_settings(CACHES=cache_settings)
-        override.__enter__()
+        override.__enter__()   # pylint: disable=unnecessary-dunder-call
         cls.__settings_overrides.append(override)
 
         assert settings.CACHES == cache_settings

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,7 @@ class CacheIsolationMixin:
 
         cls.__old_settings.append(copy.deepcopy(settings.CACHES))
         override = override_settings(CACHES=cache_settings)
-        override.__enter__()  # pylint: disable=unnecessary-dunder-call
+        override.__enter__()
         cls.__settings_overrides.append(override)
 
         assert settings.CACHES == cache_settings


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3448