### PR TITLE
fix: update pip-tools to 6.13.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,23 +23,23 @@ django-waffle==3.0.0
     # via edx-django-utils
 djangorestframework==3.14.0
     # via -r requirements/base.in
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via -r requirements/base.in
-newrelic==8.7.0
+newrelic==8.8.0
     # via edx-django-utils
 pbr==5.11.1
     # via stevedore
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
 pynacl==1.5.0
     # via edx-django-utils
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   django
     #   djangorestframework
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via edx-django-utils

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,30 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -42,7 +32,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 tox-travis==0.13
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,31 +8,19 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.0
+astroid==2.15.4
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 cffi==1.15.1
     # via
     #   -r requirements/quality.txt
     #   pynacl
-charset-normalizer==3.1.0
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
@@ -50,11 +38,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/quality.txt
@@ -84,7 +70,7 @@ django-waffle==3.0.0
     #   edx-django-utils
 djangorestframework==3.14.0
     # via -r requirements/quality.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
@@ -94,17 +80,13 @@ exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.10.0
+filelock==3.12.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 freezegun==1.2.2
     # via -r requirements/quality.txt
-idna==3.4
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -129,11 +111,11 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -147,9 +129,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -163,7 +145,7 @@ pluggy==1.0.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -179,7 +161,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pylint==2.17.0
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -207,7 +189,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -224,7 +206,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   django
@@ -234,10 +216,6 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   codecov
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -249,7 +227,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt
     #   django
@@ -273,7 +251,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -292,11 +270,7 @@ typing-extensions==4.5.0
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.15
-    # via
-    #   -r requirements/ci.txt
-    #   requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,15 +12,11 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
@@ -29,7 +25,6 @@ certifi==2022.12.7
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.1.0
     # via requests
@@ -37,12 +32,10 @@ click==8.1.3
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
-    # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
 django==3.2.18
@@ -67,7 +60,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via -r requirements/test.txt
 exceptiongroup==1.1.1
     # via
@@ -79,7 +72,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.1.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   sphinx
@@ -92,10 +85,6 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 keyring==23.13.1
@@ -108,11 +97,11 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
@@ -128,7 +117,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -136,9 +125,9 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.13.1
+pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
@@ -149,7 +138,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -162,7 +151,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
     #   freezegun
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -181,10 +170,8 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -192,7 +179,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==5.3.0
     # via
@@ -200,7 +187,7 @@ sphinx==5.3.0
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.0.0
+sphinx-book-theme==1.0.1
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -214,7 +201,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -230,7 +217,9 @@ tomli==2.0.1
 twine==4.0.2
     # via -r requirements/doc.in
 typing-extensions==4.5.0
-    # via rich
+    # via
+    #   pydata-sphinx-theme
+    #   rich
 urllib3==1.26.15
     # via
     #   requests

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,14 +8,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
@@ -31,7 +27,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -56,7 +52,7 @@ django-waffle==3.0.0
     #   edx-django-utils
 djangorestframework==3.14.0
     # via -r requirements/test.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/quality.in
@@ -80,11 +76,11 @@ markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -92,13 +88,13 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -110,7 +106,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -128,7 +124,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -143,7 +139,7 @@ python-dateutil==2.8.2
     #   freezegun
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -157,7 +153,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -174,7 +170,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,8 +8,6 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-attrs==22.2.0
-    # via pytest
 cffi==1.15.1
     # via
     #   -r requirements/base.txt
@@ -18,7 +16,7 @@ click==8.1.3
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -37,7 +35,7 @@ django-waffle==3.0.0
     #   -r requirements/base.txt
     #   edx-django-utils
     # via -r requirements/base.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via -r requirements/base.txt
 exceptiongroup==1.1.1
     # via pytest
@@ -45,11 +43,11 @@ freezegun==1.2.2
     # via -r requirements/test.in
 iniconfig==2.0.0
     # via pytest
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via pytest
 pbr==5.11.1
     # via
@@ -57,7 +55,7 @@ pbr==5.11.1
     #   stevedore
 pluggy==1.0.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -69,7 +67,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -79,14 +77,14 @@ pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via freezegun
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
 six==1.16.0
     # via python-dateutil
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django


### PR DESCRIPTION
### Description
- Latest `pip==23.1` conflicts with `pip-tools<6.13.0` so updated `pip-tools==6.13.0` to resolve the failure.