### PR TITLE
fix: check None before returning config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
+* Fixed ConfigurationModel.current: it will make sure that it does not return None for current configuration.
 
 [2.3.0] - 2022-01-19
 ~~~~~~~~~~~~~~~~~~~~

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -131,7 +131,7 @@ class ConfigurationModel(models.Model):
         """
         cache_key = cls.cache_key_name(*args)
         cached_response = TieredCache.get_cached_response(cache_key)
-        if cached_response.is_found:
+        if cached_response.is_found and cached_response.value is not None:
             return cached_response.value
 
         key_dict = dict(zip(cls.KEY_FIELDS, args))


### PR DESCRIPTION
**Description**
While replacing `python-memcache` with `pymemcache` [ticket link](https://github.com/edx/edx-arch-experiments/issues/92) we got the following error

```
  File "/edx/app/edxapp/edx-platform/xmodule/video_block/video_block.py", line 244, in student_view
    fragment = Fragment(self.get_html())
  File "/edx/app/edxapp/edx-platform/xmodule/video_block/video_block.py", line 355, in get_html
    branding_info = BrandingInfoConfig.get_config().get(user_location)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/branding/models.py", line 54, in get_config
    return json.loads(info.configuration) if info.enabled else {}
AttributeError: 'NoneType' object has no attribute 'enabled'
```

The reason of above mentioned error was: `django-config-models` was returning `None`.

Which was then used by `edx-platform`  which tries to retrieve values from `None`

https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/branding/models.py#L54

<img width="708" alt="image" src="https://github.com/openedx/django-config-models/assets/42294172/8fd0d5c7-9e0f-42aa-949f-459cf5b414fb">

This causes errors. In this PR, we're making sure that `ConfigurationModel.current` doesn't not return `None`.