### PR TITLE
docs: Update classifiers to match current state.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,12 +117,13 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
We dropped support for Django 3.2 and added support for Python 3.11 and
12 in recent PRs but we didn't update the classifiers so doing that
here.

Python Upgarde PR: https://github.com/openedx/django-config-models/pull/333
