### PR TITLE
fix: respect ConfigurationModel.enabled

### DIFF
--- a/config_models/models.py
+++ b/config_models/models.py
@@ -135,9 +135,8 @@ class ConfigurationModel(models.Model):
             return cached_response.value
 
         key_dict = dict(zip(cls.KEY_FIELDS, args))
-        try:
-            current = cls.objects.filter(**key_dict).order_by('-change_date')[0]
-        except IndexError:
+        current = cls.objects.filter(**key_dict).order_by('-change_date').first()
+        if not current or not current.enabled:
             current = cls(**key_dict)
 
         TieredCache.set_all_tiers(cache_key, current, cls.cache_timeout)


### PR DESCRIPTION
`ConfigurationModel.current()` does not respect the enabled flag and uses the same configuration values even though the configuration is disabled. This PR fixes the issue and uses default configs if the configurations are disabled using the `ConfigurationModel.enabled` flag.