### PR TITLE
fix: pypi-publish master branch sunset

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -25,7 +25,7 @@ jobs:
          run: python setup.py sdist bdist_wheel
 
        - name: Publish to PyPi
-         uses: pypa/gh-action-pypi-publish@master
+         uses: pypa/gh-action-pypi-publish@release/v1
          with:
            user: __token__
            password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
This will fix the warning of 'The master branch version has been sunset for gh-action-pypi-publisher'