### PR TITLE
Fix Model.save() call for Django 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [quality, docs, django42-drflatest, django52-drflatest, check_keywords]
+        toxenv: [quality, docs, django42-drflatest, django52-drflatest, django60-drflatest, check_keywords]
     steps:
     - uses: actions/checkout@v6
     - name: setup python
@@ -38,7 +38,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='django52-drflatest'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django60-drflatest'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/config_models/__init__.py
+++ b/config_models/__init__.py
@@ -2,4 +2,4 @@
 Configuration models for Django allowing config management with auditing.
 """
 
-__version__ = '2.9.0'
+__version__ = '2.10.0'

--- a/config_models/models.py
+++ b/config_models/models.py
@@ -101,10 +101,10 @@ class ConfigurationModel(models.Model):
         # Always create a new entry, instead of updating an existing model
         self.pk = None
         super().save(
-            force_insert,
-            force_update,
-            using,
-            update_fields
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields
         )
         TieredCache.delete_all_tiers(self.cache_key_name(*[getattr(self, key) for key in self.KEY_FIELDS]))
         if self.KEY_FIELDS:

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312}-django{42, 52, 60}-drf{latest},quality,docs
+envlist = py3{11, 12}-django{42, 52}-drf{latest},py312-django60-drf{latest},quality,docs
 
 [pycodestyle]
 exclude = .git,.tox,migrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312}-django{42, 52}-drf{latest},quality,docs
+envlist = py{311, 312}-django{42, 52, 60}-drf{latest},quality,docs
 
 [pycodestyle]
 exclude = .git,.tox,migrations
@@ -22,6 +22,7 @@ deps =
     wheel
     django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
Django 6.0 disallows Model.save() calls with positional arguments: https://docs.djangoproject.com/en/6.0/releases/6.0/