### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+Unreleased
+~~~~~~~~~~~~~~~~~~~~
+
+* Dropped Django 4.2 support; updated Sphinx intersphinx to Django 5.2 docs; bumped djangorestframework
+
 [2.9.0] - 2025-04-12
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -501,7 +501,7 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.11', None),
-    'django': ('https://docs.djangoproject.com/en/4.2/', 'https://docs.djangoproject.com/en/4.2/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/5.2/', 'https://docs.djangoproject.com/en/5.2/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
 }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ django-crum==0.7.9
     # via edx-django-utils
 django-waffle==5.0.0
     # via edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via -r requirements/base.in
 edx-django-utils==8.0.1
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -28,11 +28,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.48.1
+tox==4.50.3
     # via -r requirements/ci.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ build==1.4.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.0.3
+cachetools==7.0.5
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -38,7 +38,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -46,7 +46,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -78,17 +78,17 @@ django-waffle==5.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via -r requirements/quality.txt
 edx-django-release-util==1.5.0
     # via -r requirements/quality.txt
 edx-django-utils==8.0.1
     # via -r requirements/quality.txt
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/dev.in
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/quality.txt
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -207,7 +207,7 @@ pytest==9.0.2
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/quality.txt
 pytest-django==4.12.0
     # via -r requirements/quality.txt
@@ -215,7 +215,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   freezegun
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -260,9 +260,9 @@ tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.48.1
+tox==4.50.3
     # via -r requirements/ci.txt
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,20 +23,17 @@ certifi==2026.2.25
 cffi==2.0.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.6
     # via requests
 click==8.3.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.5
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 django==5.2.12
@@ -56,7 +53,7 @@ django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via -r requirements/test.txt
 docutils==0.22.4
     # via
@@ -81,14 +78,10 @@ iniconfig==2.3.0
     #   pytest
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via sphinx
 keyring==25.7.0
@@ -108,7 +101,6 @@ nh3==0.3.3
 packaging==26.0
     # via
     #   -r requirements/test.txt
-    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   twine
@@ -125,7 +117,7 @@ pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.15.4
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.19.2
     # via
@@ -145,7 +137,7 @@ pytest==9.0.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
@@ -174,8 +166,6 @@ rich==14.3.3
     # via twine
 roman-numerals==4.1.0
     # via sphinx
-secretstorage==3.5.0
-    # via keyring
 six==1.17.0
     # via
     #   -r requirements/test.txt
@@ -190,7 +180,7 @@ sphinx==9.1.0
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ wheel==0.46.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.0.1
     # via -r requirements/pip.in
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -25,9 +25,9 @@ click==8.3.1
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-lint
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -52,13 +52,13 @@ django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via -r requirements/test.txt
 edx-django-release-util==1.5.0
     # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via -r requirements/test.txt
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/quality.in
 freezegun==1.5.5
     # via -r requirements/test.txt
@@ -124,7 +124,7 @@ pytest==9.0.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ click==8.3.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -69,7 +69,7 @@ pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in


### PR DESCRIPTION
Dropped django 4.2 support. Bumped dependencies

Issue: https://github.com/openedx/public-engineering/issues/458