### PR TITLE
Upgrade pip-tools to 7.6.1 to fix pip 26.2 compatibility

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,19 +6,19 @@
 #
 build==1.5.0
     # via pip-tools
-click==8.3.3
+click==8.4.2
     # via pip-tools
-packaging==26.2
+packaging==26.3
     # via
     #   build
     #   wheel
-pip-tools==7.5.3
+pip-tools==7.6.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.47.0
+wheel==0.48.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Description

`pip-tools==7.5.3` is incompatible with `pip>=26.2`, which added a required `allow_editables` keyword argument to `RequirementCommand.make_requirement_preparer()`. This causes the scheduled `upgrade_requirements` CI job to fail with:

```
TypeError: RequirementCommand.make_requirement_preparer() missing 1 required keyword-only argument: 'allow_editables'
```

This bumps `pip-tools` from 7.5.3 to 7.6.1 (along with its dependencies) to restore compatibility.

Failed run: https://github.com/openedx/django-config-models/actions/runs/31990806927/job/95273901402

## Testing

The `upgrade_requirements` CI job on this PR should pass.